### PR TITLE
Added check for environments that have plugins disabled via wp-config…

### DIFF
--- a/better-search-replace.php
+++ b/better-search-replace.php
@@ -51,9 +51,16 @@ if ( ! defined( 'WPINC' ) ) {
  * @since    1.0.0
  */
 function run_better_search_replace() {
+    
+    // Check the plugin install state and user permissions to determine the best capability to use for filtering
+    if( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS && current_user_can( apply_filters( 'bsr_capability', 'manage_options' ) ) ) {
+        $capability = 'manage_options';	
+    } else {
+        $capability = 'install_plugins';
+    }
 
 	// Allows for overriding the capability required to run the plugin.
-	$cap = apply_filters( 'bsr_capability', 'install_plugins' );
+	$cap = apply_filters( 'bsr_capability', $capability );
 
 	// Only load for admins.
 	if ( current_user_can( $cap ) ) {

--- a/includes/class-bsr-admin.php
+++ b/includes/class-bsr-admin.php
@@ -81,7 +81,7 @@ class BSR_Admin {
 	 * @access public
 	 */
 	public function bsr_menu_pages() {
-		$cap = apply_filters( 'bsr_capability', 'install_plugins' );
+		$cap = apply_filters( 'bsr_capability', $this->get_capability_filter() );
 		add_submenu_page( 'tools.php', __( 'Better Search Replace', 'better-search-replace' ), __( 'Better Search Replace', 'better-search-replace' ), $cap, 'better-search-replace', array( $this, 'bsr_menu_pages_callback' ) );
 	}
 
@@ -260,7 +260,7 @@ class BSR_Admin {
 	public function download_sysinfo() {
 		check_admin_referer( 'bsr_download_sysinfo', 'bsr_sysinfo_nonce' );
 
-		$cap = apply_filters( 'bsr_capability', 'install_plugins' );
+		$cap = apply_filters( 'bsr_capability', $this->get_capability_filter() );
 		if ( ! current_user_can( $cap ) ) {
 			return;
 		}
@@ -290,6 +290,18 @@ class BSR_Admin {
 		}
 
   		return $links;
+	}
+	
+	/**
+	 * Checks the plugin install state and user permissions to determine the best capability to use for filtering
+	 * @access public
+	 */
+	public function get_capability_filter() {
+		if( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS && current_user_can( apply_filters( 'bsr_capability', 'manage_options' ) ) ) {
+			return 'manage_options';	
+		}
+		
+		return 'install_plugins';
 	}
 
 }


### PR DESCRIPTION
… to still allow admins to use Better Search Replace from the tools menu.

Created function within BSR_Admin to allow for getting an appropriate capability to work in different types of environments, and also used same code in function that initially runs the plugin.

Fixes #74 