### PR TITLE
Update class-bsr-db.php

### DIFF
--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -341,6 +341,7 @@ class BSR_DB {
 					$_tmp = $data;
 					$props = get_object_vars( $data );
 					foreach ( $props as $key => $value ) {
+						$key = trim( $key );
 						$_tmp->$key = $this->recursive_unserialize_replace( $from, $to, $value, false, $case_insensitive );
 					}
 


### PR DESCRIPTION
Resolves #71 PHP Fatal error:  Uncaught Error: Cannot access property started with '\0' in /var/www/quick2web/wp-content/plugins/better-search-replace/includes/class-bsr-db.php:344