### PR TITLE
Objects with numerical properties no longer cause errors

### DIFF
--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -352,7 +352,7 @@ class BSR_DB {
 					$props = get_object_vars( $data );
 					foreach ( $props as $key => $value ) {
 						// Integer properties are crazy and the best thing we can do is to just ignore them.
-						// see http://stackoverflow.com/a/10333200 and https://github.com/deliciousbrains/wp-migrate-db-pro/issues/853
+						// see http://stackoverflow.com/a/10333200
 						if (is_int($key)) {
 							continue;
 						}

--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -351,6 +351,18 @@ class BSR_DB {
 					$_tmp = $data;
 					$props = get_object_vars( $data );
 					foreach ( $props as $key => $value ) {
+                        // Integer properties are crazy and the best thing we can do is to just ignore them.
+                        // see http://stackoverflow.com/a/10333200 and https://github.com/deliciousbrains/wp-migrate-db-pro/issues/853
+                        if (is_int($key)) {
+                            continue;
+                        }
+
+                        // Skip any representation of a protected property
+                        // https://github.com/deliciousbrains/better-search-replace/issues/71#issuecomment-1369195244
+                        if (is_string($key) && 1 === preg_match("/^([\\][0])?/im", $key)) {
+                            continue;
+                        }
+
 						$_tmp->$key = $this->recursive_unserialize_replace( $from, $to, $value, false, $case_insensitive );
 					}
 

--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -351,17 +351,17 @@ class BSR_DB {
 					$_tmp = $data;
 					$props = get_object_vars( $data );
 					foreach ( $props as $key => $value ) {
-                        // Integer properties are crazy and the best thing we can do is to just ignore them.
-                        // see http://stackoverflow.com/a/10333200 and https://github.com/deliciousbrains/wp-migrate-db-pro/issues/853
-                        if (is_int($key)) {
-                            continue;
-                        }
+						// Integer properties are crazy and the best thing we can do is to just ignore them.
+						// see http://stackoverflow.com/a/10333200 and https://github.com/deliciousbrains/wp-migrate-db-pro/issues/853
+						if (is_int($key)) {
+							continue;
+						}
 
-                        // Skip any representation of a protected property
-                        // https://github.com/deliciousbrains/better-search-replace/issues/71#issuecomment-1369195244
-                        if (is_string($key) && 1 === preg_match("/^([\\][0])?/im", $key)) {
-                            continue;
-                        }
+						// Skip any representation of a protected property
+						// https://github.com/deliciousbrains/better-search-replace/issues/71#issuecomment-1369195244
+						if (is_string($key) && 1 === preg_match("/^([\\][0])?/im", $key)) {
+							continue;
+						}
 
 						$_tmp->$key = $this->recursive_unserialize_replace( $from, $to, $value, false, $case_insensitive );
 					}


### PR DESCRIPTION
Serialized protected properties in are now skipped during find and replace to avoid errors with different versions of PHP. Also, properties that have integer names are now skipped.