### PR TITLE
Text strings are now only deserialized when containing a match

### DIFF
--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -330,6 +330,11 @@ class BSR_DB {
 	 */
 	public function recursive_unserialize_replace( $from = '', $to = '', $data = '', $serialised = false, $case_insensitive = false ) {
 		try {
+			// If search string doesn't exist in data, do an early return.
+			if ( is_string( $data ) && false === strpos( $data, $from ) ) {
+				return $data;
+			}
+
 			if ( is_string( $data ) && ! is_serialized_string( $data ) && ( $unserialized = $this->unserialize( $data ) ) !== false ) {
 				$data = $this->recursive_unserialize_replace( $from, $to, $unserialized, true, $case_insensitive );
 			}


### PR DESCRIPTION
Strings/Serialized Strings that don't contain a match for a search term are now completely skipped without attempting to unserialize the string.

