### PR TITLE
Case insensitive setting now works for serialized data

### DIFF
--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -330,9 +330,12 @@ class BSR_DB {
 	 */
 	public function recursive_unserialize_replace( $from = '', $to = '', $data = '', $serialised = false, $case_insensitive = false ) {
 		try {
-			// If search string doesn't exist in data, do an early return.
-			if ( is_string( $data ) && false === strpos( $data, $from ) ) {
-				return $data;
+			// Exit early if $data is a string but has no search matches.
+			if ( is_string( $data ) ) {
+				$has_match = $case_insensitive ? false !== stripos( $data, $from ) : false !== strpos( $data, $from );
+				if ( ! $has_match ) {
+					return $data;
+				}
 			}
 
 			if ( is_string( $data ) && ! is_serialized_string( $data ) && ( $unserialized = $this->unserialize( $data ) ) !== false ) {
@@ -360,13 +363,13 @@ class BSR_DB {
 						if ( is_int( $key ) ) {
 							continue;
 						}
- 
+
 						// Skip any representation of a protected property
 						// https://github.com/deliciousbrains/better-search-replace/issues/71#issuecomment-1369195244
 						if ( is_string( $key ) && 1 === preg_match( "/^(\\\\0).+/im", preg_quote( $key ) ) ) {
 							continue;
 						}
- 
+
 						$_tmp->$key = $this->recursive_unserialize_replace( $from, $to, $value, false, $case_insensitive );
 					}
 


### PR DESCRIPTION
Resolves: [DELI-1014]

In BSR & BSR-PRO v1.4.6, we introduced an _early return_ to skip out of recursive search/replace in serialized data if the target $data is a string (as opposed to object or array) but doesn't contain the search term. However, the early return logic always uses `strpos()` regardless of what the `$case_insensitive`setting is.

In this PR, this is changed so that we select `strpos()`  or `stripos()` for comparing strings depending on the value of  `$case_insensitive`.

## To test

Using version 1.4.6:
1. Add serialized data containing uppercase text to the options table:
  `wp option update --format=json foobar '{"value":"UPPERCASE"}'`
2. In BSR, do a dry-run search for "uppercase" in wp_options with **Case-Insensitive** checked.
3. Note that it reports zero hits.
4. Run the search/replace anyway. 
5. Verify that nothing was changed and that foobar still contains "UPPERCASE":
    `wp option get foobar`

Using this PR:
7. In BSR, do a dry-run search for "uppercase" in wp_options with **Case-Insensitive** unchecked.
8. Note that it reports 0 hits.
9. Do another dry-run search for "uppercase" in wp_options, this time with **Case-Insensitive** checked. 
10. Note that it now reports 1 hit.
11. Run the search/replace.
12. Verify that "UPPERCASE" was replaced with the new value:
    `wp option get foobar`

[DELI-1014]: https://wpengine.atlassian.net/browse/DELI-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ