### PR TITLE
Update BSR_Plugin_Updater

### DIFF
--- a/includes/class-bsr-plugin-updater.php
+++ b/includes/class-bsr-plugin-updater.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * The PluginUpdater class which can be used to pull plugin updates from a new location.
+ *
  * @package better-search-replace
  */
 
@@ -19,33 +20,38 @@ use stdClass;
 class BSR_Plugin_Updater {
 	/**
 	 * The URL where the api is located.
-	 * @var ApiUrl
+	 *
+	 * @var string
 	 */
 	private $api_url;
 
 	/**
 	 * The amount of time to wait before checking for new updates.
-	 * @var CacheTime
+	 *
+	 * @var int
 	 */
 	private $cache_time;
 
 	/**
 	 * These properties are passed in when instantiating to identify the plugin and it's update location.
-	 * @var Properties
+	 *
+	 * @var array
 	 */
 	private $properties;
 
 	/**
 	 * Get the class constructed.
 	 *
-	 * @param Properties $properties These properties are passed in when instantiating to identify the plugin and it's update location.
+	 * @param array $properties These properties are passed in when instantiating to identify the plugin and it's update location.
 	 */
 	public function __construct( $properties ) {
 		if (
 			empty( $properties['plugin_slug'] ) ||
 			empty( $properties['plugin_basename'] )
 		) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( 'WPE Secure Plugin Updater received a malformed request.' );
+
 			return;
 		}
 
@@ -65,8 +71,10 @@ class BSR_Plugin_Updater {
 	/**
 	 * Get the full plugin properties, including the directory name, version, basename, and add a transient name.
 	 *
-	 * @param Properties $properties These properties are passed in when instantiating to identify the plugin and it's update location.
-	 * @param ApiUrl     $api_url    The URL where the api is located.
+	 * @param array  $properties These properties are passed in when instantiating to identify the plugin and it's update location.
+	 * @param string $api_url    The URL where the api is located.
+	 *
+	 * @return array|null
 	 */
 	public function get_full_plugin_properties( $properties, $api_url ) {
 		$plugins = \get_plugins();
@@ -103,30 +111,33 @@ class BSR_Plugin_Updater {
 	/**
 	 * Filter the plugin update transient to take over update notifications.
 	 *
-	 * @param object $transient The site_transient_update_plugins transient.
+	 * @param ?object $transient_value The value of the `site_transient_update_plugins` transient.
 	 *
 	 * @handles site_transient_update_plugins
-	 * @return object
+	 * @return object|null
 	 */
-	public function filter_plugin_update_transient( $transient ) {
+	public function filter_plugin_update_transient( $transient_value ) {
 		// No update object exists. Return early.
-		if ( empty( $transient ) ) {
-			return $transient;
+		if ( empty( $transient_value ) ) {
+			return $transient_value;
 		}
 
 		$result = $this->fetch_plugin_info();
 
 		if ( false === $result ) {
-			return $transient;
+			return $transient_value;
 		}
+
+		$res = $this->parse_plugin_info( $result );
 
 		if ( version_compare( $this->properties['plugin_version'], $result->version, '<' ) ) {
-			$res                                 = $this->parse_plugin_info( $result );
-			$transient->response[ $res->plugin ] = $res;
-			$transient->checked[ $res->plugin ]  = $result->version;
+			$transient_value->response[ $res->plugin ] = $res;
+			$transient_value->checked[ $res->plugin ]  = $result->version;
+		} else {
+			$transient_value->no_update[ $res->plugin ] = $res;
 		}
 
-		return $transient;
+		return $transient_value;
 	}
 
 	/**
@@ -213,7 +224,6 @@ class BSR_Plugin_Updater {
 	 * @return stdClass
 	 */
 	private function parse_plugin_info( $response ) {
-
 		global $wp_version;
 
 		$res                = new stdClass();


### PR DESCRIPTION
`BSR_Plugin_Updater` has been fixed up to properly handle supplying plugin info when it is active but does not have any updates.

<img width="882" alt="Screenshot 2024-10-10 at 13 59 51" src="https://github.com/user-attachments/assets/7bc1f2ce-2b73-4b12-9220-4235a9e6fff2">


## Testing Instructions

1. Activate the plugin.
2. Clear transients (Transient Manager is good for that).
3. Before this branch: the update_plugins transient will not have a `no_update` entry for `better-search-replace/better-search-replace.php`.
4. With this branch: the update_plugins transient will have a `no_update` entry for `better-search-replace/better-search-replace.php`.
