### PR TITLE
Add a Blueprint for WP.org Live Preview

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,0 +1,15 @@
+{
+	"preferredVersions": {
+		"php": "latest",
+		"wp": "latest"
+	},
+	"features": {
+		"networking": true
+	},
+	"plugins": [
+		"better-search-replace"
+	],
+	"login": true,
+	"landingPage": "/wp-admin/admin.php?page=better-search-replace",
+	"steps": []
+}


### PR DESCRIPTION
Hi there, this PR proposes to add a Blueprint file so that Better Search Replace can have a Live Preview button in the WP.org plugin repo. The Live Preview will load your plugin in the WordPress Playground web app using the provided Blueprint.

According to [the WP.org docs](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/#enabling-plugin-previews):

> There are two things required for a plugin preview button to appear to all users:
> 1. A valid blueprint.json file must be provided in a blueprints sub-directory of the plugin’s assets folder.
> 2. The plugin preview must be set to “public” from the plugin’s Advanced view by a committer.

Once those conditions are met, a Live Preview button should appear next to the Download button in the WordPress.org plugin repo, like:

![image](https://github.com/user-attachments/assets/07d7d338-0faa-4c33-83de-5991ebc081df)

Try [this link](https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6eyJwaHAiOiJsYXRlc3QiLCJ3cCI6ImxhdGVzdCJ9LCJmZWF0dXJlcyI6eyJuZXR3b3JraW5nIjp0cnVlfSwicGx1Z2lucyI6WyJiZXR0ZXItc2VhcmNoLXJlcGxhY2UiXSwibG9naW4iOnRydWUsImxhbmRpbmdQYWdlIjoiL3dwLWFkbWluL2FkbWluLnBocD9wYWdlPWJldHRlci1zZWFyY2gtcmVwbGFjZSIsInN0ZXBzIjpbXX0=) for an example of the preview. Note: This link's hash component is just the Base64-encoded JSON of the Blueprint, and you can decode in your browser's dev tools console with `JSON.parse(atob(<hash-value>))`.

Would this PR be useful to you?