### PR TITLE
Use single svn commit to deploy with fast checkout and commit

### DIFF
--- a/build-cfg/better-search-replace/pre-zip.php
+++ b/build-cfg/better-search-replace/pre-zip.php
@@ -7,7 +7,9 @@ if ( ! $publish ) {
 echo 'Publish to WP.org? (Y/n) ';
 if ( 'Y' == strtoupper( trim( fgets( STDIN ) ) ) ) {
 	system( 'rm -fR svn' ); // Cleanup before checkout to prevent errors
-	system( 'svn co -q http://svn.wp-plugins.org/better-search-replace svn' );
+	system( 'svn co -q --depth immediates https://plugins.svn.wordpress.org/better-search-replace/ svn' );
+	system( 'svn update -q --set-depth infinity svn/trunk' );
+	system( 'svn update -q --set-depth immediates svn/tags' );
 	system( 'rm -R svn/trunk' );
 	system( 'mkdir svn/trunk' );
 	system( "rsync -r --filter '- ext/' $plugin_slug/* svn/trunk/" );
@@ -15,12 +17,12 @@ if ( 'Y' == strtoupper( trim( fgets( STDIN ) ) ) ) {
 	system( 'mv svn/trunk/better-search-replace.php.tmp svn/trunk/better-search-replace.php' );
 	system( 'svn stat svn/ | grep \'^\?\' | awk \'{print $2}\' | xargs -I x svn add x@' );
 	system( 'svn stat svn/ | grep \'^\!\' | awk \'{print $2}\' | xargs -I x svn rm --force x@' );
+	system( "svn cp svn/trunk svn/tags/$version" );
 	system( 'svn stat svn/' );
 
 	echo 'Commit to WP.org? (Y/n)? ';
 	if ( 'Y' == strtoupper( trim( fgets( STDIN ) ) ) ) {
 		system( "svn ci --username deliciousbrains svn/ -m 'Deploy version $version'" );
-		system( "svn cp --username deliciousbrains http://svn.wp-plugins.org/better-search-replace/trunk http://svn.wp-plugins.org/better-search-replace/tags/$version  -m 'Deploy version $version'" );
 	}
 
 	system( 'rm -fR svn' ); // All done

--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
     "grunt-contrib-uglify": "^5.0.1",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-wp-i18n": "^1.0.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Resolves [DELI-1345]

This change ensures that deploying a new release to wordpress.org is a single commit that encompasses changes both in `trunk` and the `tags/x.y.z` branch that the `trunk/readme.txt` file's `Stable tag: x.y.z` references.

This should ensure that wordpress.org is able to build the zip from the appropriate `tags` branch without needing to fallback to `trunk`.

This changeset also includes an update to `package.json` to include an automatically generated `packageManager` entry that the team needs now that we're moving towards using Node's `corepack` across our plugins to ensure we have a correctly versioned package manager.

---

### Testing Instructions

```
cd build-cfg/better-search-replace
plugin-build 1.4.11-dev -p

...

Answer "Y" to "Publish to WP.org? (Y/n)"

...

A         svn/tags/1.4.11-dev
A  +    svn/tags/1.4.11-dev
M  +    svn/tags/1.4.11-dev/README.txt
M  +    svn/tags/1.4.11-dev/better-search-replace.php
M       svn/trunk/README.txt
M       svn/trunk/better-search-replace.php

...

Check that output includes creation of new tag, plus any changes that are also visible in trunk.

In another terminal session go into builds/svn and check that the new tag also includes all the other files that pre-existed in trunk, not just the new and updated files.

Answer "n" to "Commit to WP.org? (Y/n)?"
```

[DELI-1345]: https://wpengine.atlassian.net/browse/DELI-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ