### PR TITLE
WordPress core compatibility is now 7.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: wpengine, deliciousbrains, mattshaw
 Tags: search replace, search and replace, search replace database, update database urls, update live url
 Requires at least: 6.2
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 8.1
 Stable tag: 1.4.11
 License: GPLv3 or later


### PR DESCRIPTION
Update the WordPress core compatibility in the README.txt

This PR is into `master` - I will rebase `develop` on it after this is merged.